### PR TITLE
Resolution of issue #4

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,5 +13,6 @@ WriteMakefile(
   VERSION_FROM    => 'lib/Redis/hiredis.pm',
   OBJECT          => "Redis-hiredis.o $ofiles",
   C               => $cfiles,
-  OPTIMIZE        => $ENV{'OPTIMIZE'}
+  OPTIMIZE        => $ENV{'OPTIMIZE'},
+  CC              => 'gcc'
 );


### PR DESCRIPTION
Added CC Makefile override to the Makefile.PL script. This will override the use of clang on OSX and will force the usage of gcc by default.

This will resolve issue #4.

As a note, when attempting to install from cpan on OSX you will receive the error mentioned in #4, so if this pull request is accepted then please merge changes to cpan as well.

Thank you!
