### PR TITLE
Free redhi_obj in DESTROY

### DIFF
--- a/Redis-hiredis.xs
+++ b/Redis-hiredis.xs
@@ -204,3 +204,4 @@ redis_hiredis_DESTROY(self)
     CODE:
         if ( self->context != NULL )
             redisFree(self->context);
+        free(self);


### PR DESCRIPTION
Fixes memory leak where self was not freed.